### PR TITLE
fix: add variable for linux

### DIFF
--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -39,8 +39,11 @@ const watchFunction = async (fileName) => {
   console.log('something wrong...');
 };
 
+const recursive = !(
+  process.platform === 'linux' && parseInt(process.versions.node.split('.')[0], 10) >= 14
+);
 let watchTimeout;
-fs.watch(path.resolve(__dirname, '../src'), { recursive: true }, (eventType, fileName) => {
+fs.watch(path.resolve(__dirname, '../src'), { recursive }, (eventType, fileName) => {
   clearTimeout(watchTimeout);
   watchTimeout = setTimeout(() => {
     watchFunction(fileName);


### PR DESCRIPTION
https://github.com/nolimits4web/atropos/issues/15

I add a variable `recursive` so that  `fs.watch` with recursive has problems on linux and node >= 14.
https://github.com/nodejs/node/issues/36005
https://github.com/wclr/ts-node-dev/issues/143

This is working well on `Ubuntu 20.04.3 LTS`.